### PR TITLE
Add repo line counting tool and tests

### DIFF
--- a/calc_repo_lines.py
+++ b/calc_repo_lines.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+
+def count_lines_in_file(path: Path) -> tuple[int, int]:
+    """Return total and code lines for a single file."""
+    total = 0
+    code = 0
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                total += 1
+                if line.strip():
+                    code += 1
+    except (UnicodeDecodeError, OSError):
+        return 0, 0
+    return total, code
+
+
+def calc_lines(directory: Path) -> tuple[int, int]:
+    """Walk a directory tree and return total and code line counts."""
+    total = 0
+    code = 0
+    for path in directory.rglob("*"):
+        if path.is_file() and ".git" not in path.parts:
+            t, c = count_lines_in_file(path)
+            total += t
+            code += c
+    return total, code
+
+
+__all__ = ["count_lines_in_file", "calc_lines", "main"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Calculate lines of a remote repository")
+    parser.add_argument("repo", help="URL of the git repository")
+    parser.add_argument("--branch", help="Branch to checkout; defaults to repo default branch")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_cmd = ["git", "clone", "--depth", "1"]
+        if args.branch:
+            clone_cmd += ["--branch", args.branch]
+        clone_cmd += [args.repo, tmp]
+        subprocess.run(clone_cmd, check=True)
+        total, code = calc_lines(Path(tmp))
+
+    print(f"# lines: {total}")
+    print(f"# code lines: {code}")
+
+    data_dir = Path("data")
+    data_dir.mkdir(exist_ok=True)
+    results_file = data_dir / "results.txt"
+    now = _dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    line = f"Repo: {args.repo} | # lines: {total} | # code lines: {code} | Datetime: {now}\n"
+    with results_file.open("a", encoding="utf-8") as f:
+        f.write(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_calc_lines.py
+++ b/tests/test_calc_lines.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from calc_repo_lines import calc_lines, count_lines_in_file
+
+
+def test_count_lines_in_file(tmp_path: Path) -> None:
+    file = tmp_path / "file.txt"
+    file.write_text("a\n\n b \n")
+    total, code = count_lines_in_file(file)
+    assert total == 3
+    assert code == 2
+
+
+def test_calc_lines(tmp_path: Path) -> None:
+    (tmp_path / 'sub').mkdir()
+    (tmp_path / 'file1.txt').write_text('line1\n\nline3\n')
+    (tmp_path / 'sub' / 'file2.py').write_text('# comment\ncode\n')
+    # create .git file to ensure it is skipped
+    (tmp_path / '.git').mkdir()
+    (tmp_path / '.git' / 'ignore.txt').write_text('should be ignored\n')
+
+    total, code = calc_lines(tmp_path)
+    assert total == 5
+    assert code == 4


### PR DESCRIPTION
## Summary
- inline the line counting utilities into `calc_repo_lines.py`
- update tests to import from the new combined module

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.